### PR TITLE
Fix folder permission on node_modules folder & config handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,10 +19,11 @@ function live_playlists(context) {
 }
 
 live_playlists.prototype.onVolumioStart = function () {
-    var configFile = this.commandRouter.pluginManager.getConfigurationFile(this.context, 'config.json');
-
-    this.config = new (require('v-conf'))();
-    this.config.loadFile(configFile);
+    var self = this;
+    
+    self.config= new (require('v-conf'))();
+    var configFile=self.commandRouter.pluginManager.getConfigurationFile(self.context,'config.json');
+    self.config.loadFile(configFile);
 
     return libQ.resolve();
 };
@@ -550,4 +551,11 @@ live_playlists.prototype.savePluginOptions = function (data) {
 
     return defer.promise;
 
+};
+
+live_playlists.prototype.getConfigurationFiles = function()
+{
+	var self = this;
+
+	return ['config.json'];
 };

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
-echo "Initializing config"
-mkdir /data/configuration/music_service/live_playlists
-cp /data/plugins/music_service/live_playlists/config.json /data/configuration/music_service/live_playlists/config.json
-chown volumio:volumio /data/configuration/music_service/live_playlists/config.json
-
-echo "Install NodeJS dependencies"
+echo "Installing NodeJS dependencies"
 ( cd /data/plugins/music_service/live_playlists && npm install )
+chown -R volumio:volumio /data/plugins/music_service/live_playlists
 
 echo "plugininstallend"


### PR DESCRIPTION
Hi, 
I noticed that the plugin could not be uninstalled properly. It said there are problems removing the node_modules directory. This was due to the fact that the folder owner was root since the install.sh is called with root permissions. This is fixed by chowning the whole folder after npm install.

Another thing is the config handling. The config folder and file is also left-over after uninstall. The install.sh copied the file to the /data/configuration... folder manually.  The folder also had root permissions as only the config file was re-chown-ed.

I saw in [one of the default plugins](https://github.com/volumio/Volumio2/blob/146b12d2a0cd878989525a0115be46577fe9ceed/app/plugins/miscellanea/albumart/index.js)   how they handle the config. It is apparently not necessary to copy the file over. It is done automatically if the corresponding callback is implemented (was missing). The plugin folder will continue to have the initial config.  While this simplifies the plugin installation, it does not fix the issue of config residue after unistallation. Could still be a bug in volumio. 

When you try it out, make sure to remove the plugin folder completely and also the plugin's configuration folder. 

Cheers
Jochen